### PR TITLE
Fix IndexOutOfBoundsException

### DIFF
--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/stored/PlayerStorageStorage.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/stored/PlayerStorageStorage.kt
@@ -40,7 +40,6 @@ internal object PlayerStorageStorage {
             PLAYER_STORAGE.save()
         } else if (data != old) {
             val index = indexOf(old)
-            clear()
             this[index] = data
             PLAYER_STORAGE.save()
         }


### PR DESCRIPTION
Not sure if this is the right fix, because I have not really a clue of Minecraft mod development, but the `clear()` call makes the `this[index] = data` call fail with an `IndexOutOfBoundsException`.

Like this:
```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302) ~[?:?]
	at java.base/java.util.Objects.checkIndex(Objects.java:385) ~[?:?]
	at java.base/java.util.ArrayList.set(ArrayList.java:470) ~[?:?]
	at knot/tech.thatgravyboat.skyblockapi.api.data.stored.PlayerStorageStorage.setStorageInstance(PlayerStorageStorage.kt:44) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.api.data.stored.PlayerStorageStorage.setBackpack(PlayerStorageStorage.kt:32) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.api.profile.storage.StorageAPI.onInventoryLoad$lambda$4(StorageAPI.kt:38) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.utils.regex.RegexUtils.match(RegexUtils.kt:7) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.api.profile.storage.StorageAPI.onInventoryLoad(StorageAPI.kt:35) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.api.events.base.EventHandler.post(EventHandler.kt:21) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.api.events.base.EventHandler.post$default(EventHandler.kt:15) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.api.events.base.EventBus.post(EventBus.kt:36) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.api.events.base.EventBus.post$default(EventBus.kt:36) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.api.events.base.SkyBlockEvent.post(SkyBlockEvent.kt:11) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.api.events.base.SkyBlockEvent.post$skyblock_api_client(SkyBlockEvent.kt:13) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.impl.events.PacketEventHandler.onPacketReceived$lambda$2(PacketEventHandler.kt:36) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/tech.thatgravyboat.skyblockapi.helpers.McClient.tell$lambda$11(McClient.kt:80) ~[skyblock-api-1.0.0-beta.52-2b8e82c47b0d81a7.jar:?]
	at knot/net.minecraft.class_1255.method_18859(class_1255.java:162) [client-intermediary.jar:?]
	at knot/net.minecraft.class_4093.method_18859(class_4093.java:23) [client-intermediary.jar:?]
	at knot/net.minecraft.class_1255.method_16075(class_1255.java:136) [client-intermediary.jar:?]
	at knot/net.minecraft.class_1255.method_5383(class_1255.java:121) [client-intermediary.jar:?]
	at knot/net.minecraft.class_310.method_1523(class_310.java:1240) [client-intermediary.jar:?]
	at knot/net.minecraft.class_310.method_1514(class_310.java:882) [client-intermediary.jar:?]
	at knot/net.minecraft.client.main.Main.main(Main.java:256) [client-intermediary.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480) [fabric-loader-0.16.9.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) [fabric-loader-0.16.9.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) [fabric-loader-0.16.9.jar:?]
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70) [NewLaunch.jar:?]
```