### PR TITLE
Fix god pot duration thingy (look desc)

### DIFF
--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/profile/effects/EffectsAPI.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/profile/effects/EffectsAPI.kt
@@ -76,7 +76,7 @@ object EffectsAPI {
     fun onTabFooterUpdate(event: TabListHeaderFooterChangeEvent) {
         val cookieBuffChunk = event.newFooterChunked.find { "Cookie Buff" in it }
         cookieBuffChunk?.last()?.let {
-            val parsedDuration = it.parseWordDuration() ?: return
+            val parsedDuration = it.parseWordDuration() ?: return@let
             updateBoosterCookieExpireTime(parsedDuration)
         }
 


### PR DESCRIPTION
Having no cookie active, using the footer, the god pot fails to update