### PR TITLE
fix: component splitting

### DIFF
--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/utils/text/Text.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/utils/text/Text.kt
@@ -78,7 +78,7 @@ object TextUtils {
                 current.append(Component.literal(lines[0]).setStyle(style))
                 if (lines.size > 1) {
                     components.add(current)
-                    for (i in 2 until lines.lastIndex) {
+                    for (i in 1 until lines.lastIndex) {
                         components.add(Component.literal(lines[i]).setStyle(style))
                     }
                     current = Component.literal(lines.last()).setStyle(style)


### PR DESCRIPTION
fixes the translatable thing in sbpv not showing empty lines in the splitter thing

this:
![image](https://github.com/user-attachments/assets/363edfa5-7c22-4bb9-9c9a-0d9e5731111d)
![image](https://github.com/user-attachments/assets/36223ded-14c9-4ed9-b3a9-4b532905dd42)
