### PR TITLE
 Add ModMenu library badge

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,5 +27,10 @@
         "fabric-language-kotlin": ">=${kotlin_loader_version}",
         "fabric": "*",
         "minecraft": "${minecraft_version}"
+    },
+    "custom": {
+        "modmenu": {
+            "badges": ["library"]
+        }
     }
 }


### PR DESCRIPTION
Added the ModMeny library mod in the fmj. This tells ModMenu that the mod is a library and so fixes the mod being shown in the menu even when the user wants library mods hidden.