### PR TITLE
feat: add no arg event consumer

### DIFF
--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Default.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Default.kt
@@ -1,3 +1,0 @@
-package tech.thatgravyboat.skyblockapi.api.events.base
-
-internal object Default : SkyBlockEvent()

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Default.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Default.kt
@@ -1,0 +1,3 @@
+package tech.thatgravyboat.skyblockapi.api.events.base
+
+internal object Default : SkyBlockEvent()

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventBus.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventBus.kt
@@ -68,7 +68,7 @@ class EventBus {
             return options to options.event.java
         }
         if (method.parameterTypes.size != 1) return null
-        return options to (method.parameterTypes.firstOrNull() ?: options.event.java)
+        return method.parameterTypes.firstOrNull()?.let { options to it }
     }
 
     private fun unregisterHandler(clazz: Class<*>) = this.handlers.keys

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventBus.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventBus.kt
@@ -1,5 +1,6 @@
 package tech.thatgravyboat.skyblockapi.api.events.base
 
+import tech.thatgravyboat.skyblockapi.api.SkyBlockAPI
 import java.lang.reflect.Method
 
 class EventBus {
@@ -48,28 +49,51 @@ class EventBus {
     } as EventHandler<T>
 
     private fun unregisterMethod(method: Method) {
-        val (_, event) = getEventClass(method) ?: return
+        val (_, event) = getEventData(method) ?: return
+        event.forEach {
+            unregisterMethodInternal(method, it)
+        }
+    }
+
+    private fun unregisterMethodInternal(method: Method, event: Class<*>) {
         if (!SkyBlockEvent::class.java.isAssignableFrom(event)) return
         unregisterHandler(event)
         listeners.values.forEach { it.removeListener(method) }
     }
 
-    @Suppress("UNCHECKED_CAST")
     private fun registerMethod(method: Method, instance: Any) {
-        val (options, event) = getEventClass(method) ?: return
-        if (!SkyBlockEvent::class.java.isAssignableFrom(event)) return
-        unregisterHandler(event)
-        listeners.getOrPut(event as Class<SkyBlockEvent>) { EventListeners() }.addListener(method, instance, options)
+        val (options, events) = getEventData(method) ?: return
+        events.forEach {
+            registerMethodInternal(method, instance, it, options)
+        }
     }
 
-    private fun getEventClass(method: Method): Pair<Subscription, Class<*>>? {
+    @Suppress("UNCHECKED_CAST")
+    private fun registerMethodInternal(method: Method, instance: Any, event: Class<*>, options: Subscription) {
+        if (!SkyBlockEvent::class.java.isAssignableFrom(event)) return
+        unregisterHandler(event)
+        val listeners = listeners.getOrPut(event as Class<SkyBlockEvent>) { EventListeners() }
+        if (method.parameterCount == 1) {
+            listeners.addListener(method, instance, options)
+        } else {
+            SkyBlockAPI.logger.info("Registering no arg listener for ${method.declaringClass.name}::${method.name} for event ${event.name}")
+            listeners.addNoArgListener(method, instance, options)
+        }
+    }
+
+    private fun getEventData(method: Method): EventData? {
         val options = method.getAnnotation(Subscription::class.java) ?: return null
-        if (method.parameterCount == 0 && options.event != Default::class) {
-            return options to options.event.java
+        if (method.parameterCount == 0 && options.event.isNotEmpty()) {
+            return EventData(options, options.event.toList().map { it.java })
         }
         if (method.parameterTypes.size != 1) return null
-        return method.parameterTypes.firstOrNull()?.let { options to it }
+        return method.parameterTypes.firstOrNull()?.let { EventData(options, listOf(it)) }
     }
+
+    data class EventData(
+        val options: Subscription,
+        val events: List<Class<*>>,
+    )
 
     private fun unregisterHandler(clazz: Class<*>) = this.handlers.keys
         .filter { it.isAssignableFrom(clazz) }

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventBus.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventBus.kt
@@ -1,6 +1,5 @@
 package tech.thatgravyboat.skyblockapi.api.events.base
 
-import tech.thatgravyboat.skyblockapi.api.SkyBlockAPI
 import java.lang.reflect.Method
 
 class EventBus {
@@ -73,11 +72,10 @@ class EventBus {
         if (!SkyBlockEvent::class.java.isAssignableFrom(event)) return
         unregisterHandler(event)
         val listeners = listeners.getOrPut(event as Class<SkyBlockEvent>) { EventListeners() }
-        if (method.parameterCount == 1) {
-            listeners.addListener(method, instance, options)
-        } else {
-            SkyBlockAPI.logger.info("Registering no arg listener for ${method.declaringClass.name}::${method.name} for event ${event.name}")
-            listeners.addNoArgListener(method, instance, options)
+        when (method.parameterCount) {
+            1 -> listeners.addListener(method, instance, options)
+            0 -> listeners.addNoArgListener(method, instance, options)
+            else -> throw IllegalStateException("Expected method with zero or one parameters got %s".format(method.parameterCount))
         }
     }
 

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventBus.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventBus.kt
@@ -36,21 +36,19 @@ class EventBus {
     fun post(
         event: SkyBlockEvent,
         context: Any? = null,
-        onError: ((Throwable) -> Unit)? = null
+        onError: ((Throwable) -> Unit)? = null,
     ): Boolean = getHandler(event.javaClass).post(event, context, onError)
 
     @Suppress("UNCHECKED_CAST")
     private fun <T : SkyBlockEvent> getHandler(event: Class<T>): EventHandler<T> = handlers.getOrPut(event) {
         EventHandler(
             event,
-            getEventClasses(event).mapNotNull { listeners[it] }.flatMap(EventListeners::getListeners)
+            getEventClasses(event).mapNotNull { listeners[it] }.flatMap(EventListeners::getListeners),
         )
     } as EventHandler<T>
 
     private fun unregisterMethod(method: Method) {
-        if (method.parameterCount != 1) return
-        method.getAnnotation(Subscription::class.java) ?: return
-        val event = method.parameterTypes[0]
+        val (_, event) = getEventClass(method) ?: return
         if (!SkyBlockEvent::class.java.isAssignableFrom(event)) return
         unregisterHandler(event)
         listeners.values.forEach { it.removeListener(method) }
@@ -58,12 +56,19 @@ class EventBus {
 
     @Suppress("UNCHECKED_CAST")
     private fun registerMethod(method: Method, instance: Any) {
-        if (method.parameterCount != 1) return
-        val options = method.getAnnotation(Subscription::class.java) ?: return
-        val event = method.parameterTypes[0]
+        val (options, event) = getEventClass(method) ?: return
         if (!SkyBlockEvent::class.java.isAssignableFrom(event)) return
         unregisterHandler(event)
         listeners.getOrPut(event as Class<SkyBlockEvent>) { EventListeners() }.addListener(method, instance, options)
+    }
+
+    private fun getEventClass(method: Method): Pair<Subscription, Class<*>>? {
+        val options = method.getAnnotation(Subscription::class.java) ?: return null
+        if (method.parameterCount == 0 && options.event != Default::class) {
+            return options to options.event.java
+        }
+        if (method.parameterTypes.size != 1) return null
+        return options to (method.parameterTypes.firstOrNull() ?: options.event.java)
     }
 
     private fun unregisterHandler(clazz: Class<*>) = this.handlers.keys

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventListeners.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventListeners.kt
@@ -1,7 +1,6 @@
 package tech.thatgravyboat.skyblockapi.api.events.base
 
 import kotlinx.coroutines.Runnable
-import tech.thatgravyboat.skyblockapi.api.SkyBlockAPI
 import java.lang.invoke.LambdaMetafactory
 import java.lang.invoke.MethodHandles
 import java.lang.invoke.MethodType
@@ -29,20 +28,20 @@ internal class EventListeners {
         )
     }
 
+    fun addNoArgListener(method: Method, instance: Any, options: Subscription) {
+        val name = "${method.declaringClass.name}.${method.name}()"
+        listeners.add(
+            Listener(
+                method,
+                createNoArgEventConsumer(name, instance, method),
+                options.priority,
+                options.receiveCancelled,
+                EventPredicates(method),
+            ),
+        )
+    }
+
     fun addListener(method: Method, instance: Any, options: Subscription) {
-        if (method.parameterCount == 0 && options.event != Default::class) {
-            val name = "${method.declaringClass.name}.${method.name}()"
-            listeners.add(
-                Listener(
-                    method,
-                    createNoArgEventConsumer(name, instance, method),
-                    options.priority,
-                    options.receiveCancelled,
-                    EventPredicates(method),
-                ),
-            )
-            return
-        }
         val name = "${method.declaringClass.name}.${method.name}${
             method.parameterTypes.joinTo(
                 StringBuilder(),

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventListeners.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/EventListeners.kt
@@ -1,5 +1,7 @@
 package tech.thatgravyboat.skyblockapi.api.events.base
 
+import kotlinx.coroutines.Runnable
+import tech.thatgravyboat.skyblockapi.api.SkyBlockAPI
 import java.lang.invoke.LambdaMetafactory
 import java.lang.invoke.MethodHandles
 import java.lang.invoke.MethodType
@@ -16,16 +18,31 @@ internal class EventListeners {
 
     fun <T> addListener(callback: (T) -> Unit, priority: Int, receiveCancelled: Boolean) {
         @Suppress("UNCHECKED_CAST")
-        listeners.add(Listener(
-            callback,
-            { callback(it as T) },
-            priority,
-            receiveCancelled,
-            EventPredicates(listOf { event, _ -> receiveCancelled || !event.isCancelled })
-        ))
+        listeners.add(
+            Listener(
+                callback,
+                { callback(it as T) },
+                priority,
+                receiveCancelled,
+                EventPredicates(listOf { event, _ -> receiveCancelled || !event.isCancelled }),
+            ),
+        )
     }
 
     fun addListener(method: Method, instance: Any, options: Subscription) {
+        if (method.parameterCount == 0 && options.event != Default::class) {
+            val name = "${method.declaringClass.name}.${method.name}()"
+            listeners.add(
+                Listener(
+                    method,
+                    createNoArgEventConsumer(name, instance, method),
+                    options.priority,
+                    options.receiveCancelled,
+                    EventPredicates(method),
+                ),
+            )
+            return
+        }
         val name = "${method.declaringClass.name}.${method.name}${
             method.parameterTypes.joinTo(
                 StringBuilder(),
@@ -35,13 +52,32 @@ internal class EventListeners {
                 transform = Class<*>::getTypeName,
             )
         }"
-        listeners.add(Listener(
-            method,
-            createEventConsumer(name, instance, method),
-            options.priority,
-            options.receiveCancelled,
-            EventPredicates(method)
-        ))
+        listeners.add(
+            Listener(
+                method,
+                createEventConsumer(name, instance, method),
+                options.priority,
+                options.receiveCancelled,
+                EventPredicates(method),
+            ),
+        )
+    }
+
+    private fun createNoArgEventConsumer(name: String, instance: Any, method: Method): Consumer<Any> {
+        try {
+            val handle = MethodHandles.lookup().unreflect(method)
+            val runnable = LambdaMetafactory.metafactory(
+                MethodHandles.lookup(),
+                "run",
+                MethodType.methodType(Runnable::class.java, instance::class.java),
+                MethodType.methodType(Nothing::class.javaPrimitiveType),
+                handle,
+                MethodType.methodType(Nothing::class.javaPrimitiveType),
+            ).target.bindTo(instance).invokeExact() as Runnable
+            return Consumer { _ -> runnable.run() }
+        } catch (e: Throwable) {
+            throw IllegalArgumentException("Method $name is not a valid consumer", e)
+        }
     }
 
     /**

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Subscription.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Subscription.kt
@@ -18,7 +18,7 @@ annotation class Subscription(
     /**
      * The event that will be received, only is required if there are no parameters.
      */
-    val event: KClass<out SkyBlockEvent> = Default::class,
+    vararg val event: KClass<out SkyBlockEvent> = [],
 ) {
 
     companion object {

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Subscription.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Subscription.kt
@@ -1,5 +1,7 @@
 package tech.thatgravyboat.skyblockapi.api.events.base
 
+import kotlin.reflect.KClass
+
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class Subscription(
@@ -12,6 +14,11 @@ annotation class Subscription(
      * If the event is cancelled & receiveCancelled is true, then the method will still invoke.
      */
     val receiveCancelled: Boolean = false,
+
+    /**
+     * The event that will be received, only is required if there is no parameters.
+     */
+    val event: KClass<out SkyBlockEvent> = Default::class,
 ) {
 
     companion object {

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Subscription.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Subscription.kt
@@ -16,7 +16,7 @@ annotation class Subscription(
     val receiveCancelled: Boolean = false,
 
     /**
-     * The event that will be received, only is required if there is no parameters.
+     * The event that will be received, only is required if there are no parameters.
      */
     val event: KClass<out SkyBlockEvent> = Default::class,
 ) {


### PR DESCRIPTION
idk i think its not a bad solution like this, does look like this now
```kt
@Subscription(event = [ContainerCloseEvent::class, ContainerInitializedEvent::class])
fun test() {
    Text.of {
        append("Meow")
    }.send()
}
```