### PR TITLE
feat: add inline stored data support

### DIFF
--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredData.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredData.kt
@@ -5,7 +5,7 @@ import com.google.gson.JsonObject
 import com.mojang.serialization.Codec
 import net.fabricmc.loader.api.FabricLoader
 import org.apache.commons.io.FileUtils
-import tech.thatgravyboat.skyblockapi.generated.KCodec
+import tech.thatgravyboat.skyblockapi.generated.SkyblockAPICodecs
 import tech.thatgravyboat.skyblockapi.utils.Logger
 import tech.thatgravyboat.skyblockapi.utils.Scheduling
 import tech.thatgravyboat.skyblockapi.utils.extentions.getEmptyConstructor
@@ -115,7 +115,7 @@ internal class StoredData<T : Any>(
         inline operator fun <reified T : Any> invoke(
             file: String,
             version: Int = 0,
-            codec: Codec<T> = KCodec.getCodec<T>(),
+            codec: Codec<T> = SkyblockAPICodecs.getCodec<T>(),
         ): StoredData<T> {
             return create(T::class, file, version) { codec }
         }

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredData.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredData.kt
@@ -111,6 +111,7 @@ internal class StoredData<T : Any>(
     companion object {
         val defaultPath: Path = FabricLoader.getInstance().configDir.resolve("skyblockapi")
 
+        /** Only use if [T] has an empty constructor. */
         inline operator fun <reified T : Any> invoke(
             file: String,
             version: Int = 0,
@@ -119,6 +120,7 @@ internal class StoredData<T : Any>(
             return create(T::class, file, version) { codec }
         }
 
+        /** Only use if [T] has an empty constructor. */
         inline operator fun <reified T : Any> invoke(
             file: String,
             version: Int = 0,

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredData.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredData.kt
@@ -5,8 +5,10 @@ import com.google.gson.JsonObject
 import com.mojang.serialization.Codec
 import net.fabricmc.loader.api.FabricLoader
 import org.apache.commons.io.FileUtils
+import tech.thatgravyboat.skyblockapi.generated.KCodec
 import tech.thatgravyboat.skyblockapi.utils.Logger
 import tech.thatgravyboat.skyblockapi.utils.Scheduling
+import tech.thatgravyboat.skyblockapi.utils.extentions.getEmptyConstructor
 import tech.thatgravyboat.skyblockapi.utils.json.Json.readJson
 import tech.thatgravyboat.skyblockapi.utils.json.Json.toDataOrThrow
 import tech.thatgravyboat.skyblockapi.utils.json.Json.toJson
@@ -15,6 +17,7 @@ import tech.thatgravyboat.skyblockapi.utils.json.JsonObject
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.ScheduledFuture
+import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.milliseconds
 
 private const val SAVE_DELAY = 1000 * 10
@@ -107,5 +110,32 @@ internal class StoredData<T : Any>(
 
     companion object {
         val defaultPath: Path = FabricLoader.getInstance().configDir.resolve("skyblockapi")
+
+        inline operator fun <reified T : Any> invoke(
+            file: String,
+            version: Int = 0,
+            codec: Codec<T> = KCodec.getCodec<T>(),
+        ): StoredData<T> {
+            return create(T::class, file, version) { codec }
+        }
+
+        inline operator fun <reified T : Any> invoke(
+            file: String,
+            version: Int = 0,
+            noinline codec: (Int) -> Codec<T>,
+        ) = create(T::class, file, version, codec)
+
+
+        fun <T : Any> create(
+            kClass: KClass<T>,
+            file: String,
+            version: Int,
+            codec: (Int) -> Codec<T>,
+        ): StoredData<T> {
+            val constructor = kClass.getEmptyConstructor()
+            requireNotNull(constructor) { "No empty constructor found for ${kClass.simpleName}" }
+            val data = constructor.callBy(emptyMap())
+            return StoredData(version, data, file, codec)
+        }
     }
 }

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredPlayerData.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredPlayerData.kt
@@ -38,6 +38,7 @@ internal class StoredPlayerData<T : Any>(
 
 
     companion object {
+        /** Only use if [T] has an empty constructor. */
         inline operator fun <reified T : Any> invoke(
             file: String,
             version: Int = 0,
@@ -46,6 +47,7 @@ internal class StoredPlayerData<T : Any>(
             return create(T::class, file, version) { codec }
         }
 
+        /** Only use if [T] has an empty constructor. */
         inline operator fun <reified T : Any> invoke(
             file: String,
             version: Int = 0,

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredPlayerData.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredPlayerData.kt
@@ -4,7 +4,9 @@ import com.mojang.serialization.Codec
 import tech.thatgravyboat.skyblockapi.generated.KCodec
 import tech.thatgravyboat.skyblockapi.helpers.McPlayer
 import tech.thatgravyboat.skyblockapi.utils.codecs.CodecUtils
+import tech.thatgravyboat.skyblockapi.utils.extentions.getEmptyConstructor
 import java.util.*
+import kotlin.reflect.KClass
 
 internal class StoredPlayerData<T : Any>(
     version: Int = 0,
@@ -33,4 +35,36 @@ internal class StoredPlayerData<T : Any>(
     fun get(): T = storedData.get().getOrPut(McPlayer.uuid, data)
 
     fun save() = storedData.save()
+
+
+    companion object {
+        inline operator fun <reified T : Any> invoke(
+            file: String,
+            version: Int = 0,
+            codec: Codec<T> = KCodec.getCodec<T>(),
+        ): StoredPlayerData<T> {
+            return create(T::class, file, version) { codec }
+        }
+
+        inline operator fun <reified T : Any> invoke(
+            file: String,
+            version: Int = 0,
+            noinline codec: (Int) -> Codec<T>,
+        ) = create(T::class, file, version, codec)
+
+
+        fun <T : Any> create(
+            kClass: KClass<T>,
+            file: String,
+            version: Int,
+            codec: (Int) -> Codec<T>,
+        ): StoredPlayerData<T> {
+            val constructor = kClass.getEmptyConstructor()
+            requireNotNull(constructor) { "No empty constructor found for ${kClass.simpleName}" }
+            val data: () -> T = {
+                constructor.callBy(emptyMap())
+            }
+            return StoredPlayerData(version, data, file, codec)
+        }
+    }
 }

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredPlayerData.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredPlayerData.kt
@@ -2,6 +2,7 @@ package tech.thatgravyboat.skyblockapi.api.data
 
 import com.mojang.serialization.Codec
 import tech.thatgravyboat.skyblockapi.generated.KCodec
+import tech.thatgravyboat.skyblockapi.generated.SkyblockAPICodecs
 import tech.thatgravyboat.skyblockapi.helpers.McPlayer
 import tech.thatgravyboat.skyblockapi.utils.codecs.CodecUtils
 import tech.thatgravyboat.skyblockapi.utils.extentions.getEmptyConstructor
@@ -42,7 +43,7 @@ internal class StoredPlayerData<T : Any>(
         inline operator fun <reified T : Any> invoke(
             file: String,
             version: Int = 0,
-            codec: Codec<T> = KCodec.getCodec<T>(),
+            codec: Codec<T> = SkyblockAPICodecs.getCodec<T>(),
         ): StoredPlayerData<T> {
             return create(T::class, file, version) { codec }
         }

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredProfileData.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredProfileData.kt
@@ -3,6 +3,7 @@ package tech.thatgravyboat.skyblockapi.api.data
 import com.mojang.serialization.Codec
 import tech.thatgravyboat.skyblockapi.api.profile.profile.ProfileAPI
 import tech.thatgravyboat.skyblockapi.generated.KCodec
+import tech.thatgravyboat.skyblockapi.generated.SkyblockAPICodecs
 import tech.thatgravyboat.skyblockapi.helpers.McPlayer
 import tech.thatgravyboat.skyblockapi.utils.codecs.CodecUtils
 import tech.thatgravyboat.skyblockapi.utils.extentions.getEmptyConstructor
@@ -27,7 +28,7 @@ internal class StoredProfileData<T : Any>(
         inline operator fun <reified T : Any> invoke(
             file: String,
             version: Int = 0,
-            codec: Codec<T> = KCodec.getCodec<T>(),
+            codec: Codec<T> = SkyblockAPICodecs.getCodec<T>(),
         ): StoredProfileData<T> {
             return create(T::class, file, version) { codec }
         }

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredProfileData.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredProfileData.kt
@@ -15,27 +15,33 @@ internal class StoredProfileData<T : Any>(
     file: String,
     codec: (Int) -> Codec<T>,
 ) {
+    constructor(data: () -> T, codec: Codec<T>, file: String) : this(
+        0,
+        data,
+        file,
+        { codec },
+    )
 
     companion object {
-        inline operator fun <reified T : Any> invoke(file: String): StoredProfileData<T> {
-            val codec = KCodec.getCodec<T>()
-            return create(T::class, 0, file) { codec }
+        inline operator fun <reified T : Any> invoke(
+            file: String,
+            version: Int = 0,
+            codec: Codec<T> = KCodec.getCodec<T>(),
+        ): StoredProfileData<T> {
+            return create(T::class, file, version) { codec }
         }
 
-        inline operator fun <reified T : Any> invoke(codec: Codec<T>, file: String) =
-            create(T::class, 0, file) { codec }
-
         inline operator fun <reified T : Any> invoke(
-            version: Int = 0,
             file: String,
+            version: Int = 0,
             noinline codec: (Int) -> Codec<T>,
-        ) = create(T::class, version, file, codec)
+        ) = create(T::class, file, version, codec)
 
 
         fun <T : Any> create(
             kClass: KClass<T>,
-            version: Int = 0,
             file: String,
+            version: Int,
             codec: (Int) -> Codec<T>,
         ): StoredProfileData<T> {
             val constructor = kClass.getEmptyConstructor()
@@ -46,13 +52,6 @@ internal class StoredProfileData<T : Any>(
             return StoredProfileData(version, data, file, codec)
         }
     }
-
-    constructor(data: () -> T, codec: Codec<T>, file: String) : this(
-        0,
-        data,
-        file,
-        { codec },
-    )
 
     private val storedData = StoredData(
         version,

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredProfileData.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredProfileData.kt
@@ -23,6 +23,7 @@ internal class StoredProfileData<T : Any>(
     )
 
     companion object {
+        /** Only use if [T] has an empty constructor. */
         inline operator fun <reified T : Any> invoke(
             file: String,
             version: Int = 0,
@@ -31,6 +32,7 @@ internal class StoredProfileData<T : Any>(
             return create(T::class, file, version) { codec }
         }
 
+        /** Only use if [T] has an empty constructor. */
         inline operator fun <reified T : Any> invoke(
             file: String,
             version: Int = 0,

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredProfileData.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/StoredProfileData.kt
@@ -5,7 +5,9 @@ import tech.thatgravyboat.skyblockapi.api.profile.profile.ProfileAPI
 import tech.thatgravyboat.skyblockapi.generated.KCodec
 import tech.thatgravyboat.skyblockapi.helpers.McPlayer
 import tech.thatgravyboat.skyblockapi.utils.codecs.CodecUtils
+import tech.thatgravyboat.skyblockapi.utils.extentions.getEmptyConstructor
 import java.util.*
+import kotlin.reflect.KClass
 
 internal class StoredProfileData<T : Any>(
     version: Int = 0,
@@ -13,6 +15,37 @@ internal class StoredProfileData<T : Any>(
     file: String,
     codec: (Int) -> Codec<T>,
 ) {
+
+    companion object {
+        inline operator fun <reified T : Any> invoke(file: String): StoredProfileData<T> {
+            val codec = KCodec.getCodec<T>()
+            return create(T::class, 0, file) { codec }
+        }
+
+        inline operator fun <reified T : Any> invoke(codec: Codec<T>, file: String) =
+            create(T::class, 0, file) { codec }
+
+        inline operator fun <reified T : Any> invoke(
+            version: Int = 0,
+            file: String,
+            noinline codec: (Int) -> Codec<T>,
+        ) = create(T::class, version, file, codec)
+
+
+        fun <T : Any> create(
+            kClass: KClass<T>,
+            version: Int = 0,
+            file: String,
+            codec: (Int) -> Codec<T>,
+        ): StoredProfileData<T> {
+            val constructor = kClass.getEmptyConstructor()
+            requireNotNull(constructor) { "No empty constructor found for ${kClass.simpleName}" }
+            val data: () -> T = {
+                constructor.callBy(emptyMap())
+            }
+            return StoredProfileData(version, data, file, codec)
+        }
+    }
 
     constructor(data: () -> T, codec: Codec<T>, file: String) : this(
         0,

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/stored/MaxwellStorage.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/data/stored/MaxwellStorage.kt
@@ -14,11 +14,7 @@ private const val MINIMUM_DIFFERENCE_TUNING_CHANGE = 1.5
 
 internal object MaxwellStorage {
 
-    private val DATA = StoredProfileData(
-        ::MaxwellData,
-        MaxwellData.CODEC,
-        "maxwell.json"
-    )
+    private val DATA = StoredProfileData<MaxwellData>("maxwell.json")
 
     private inline val data: MaxwellData? get() = DATA.get()
 

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/utils/extentions/ReflectionExtensions.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/utils/extentions/ReflectionExtensions.kt
@@ -1,6 +1,13 @@
 package tech.thatgravyboat.skyblockapi.utils.extentions
 
 import java.lang.reflect.Method
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
 
 inline fun <reified T : Annotation> Method.getAnnotation(): T? =
     getAnnotation(T::class.java)
+
+fun <T : Any> KClass<T>.getEmptyConstructor(): KFunction<T>? =
+    constructors.find { constructor ->
+        constructor.parameters.all { it.isOptional }
+    }


### PR DESCRIPTION
Adds support for creating StoredData/StoredPlayerData/StoredProfileData without specifying the default data instance and/or codec, by getting an empty constructor via reflection, and the codec by KCodec if not specified.

Kotlin doesnt support inline and reified constructors, so a workaround is adding an invoke operator to the companion object, which makes it look like a constructor.