### PR TITLE
style: move event parameter in subscription annotation

### DIFF
--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/area/farming/TrapperAPI.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/area/farming/TrapperAPI.kt
@@ -69,10 +69,7 @@ object TrapperAPI {
         this.trackedLocation = SkyBlockAreas.NONE
     }
 
-    @Subscription
-    fun onProfileChange(event: ProfileChangeEvent) = reset()
-
-    @Subscription
-    fun onDisconnect(event: ServerDisconnectEvent) = reset()
+    @Subscription(ProfileChangeEvent::class, ServerDisconnectEvent::class)
+    fun onProfileChange() = reset()
 }
 

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/area/hub/CarnivalAPI.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/area/hub/CarnivalAPI.kt
@@ -50,9 +50,6 @@ object CarnivalAPI {
         duration = Duration.ZERO
     }
 
-    @Subscription
-    fun onDisconnect(event: ServerDisconnectEvent) = reset()
-
-    @Subscription
-    fun onSwapProfile(event: ProfileChangeEvent) = reset()
+    @Subscription(ProfileChangeEvent::class, ServerDisconnectEvent::class)
+    fun onProfileChange() = reset()
 }

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/area/hub/SpookyFestivalAPI.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/area/hub/SpookyFestivalAPI.kt
@@ -63,11 +63,8 @@ object SpookyFestivalAPI {
         } ?: reset()
     }
 
-    @Subscription
-    fun onProfileChange(event: ProfileChangeEvent) = reset()
-
-    @Subscription
-    fun onDisconnect(event: ServerDisconnectEvent) = reset()
+    @Subscription(ProfileChangeEvent::class, ServerDisconnectEvent::class)
+    fun onProfileChange() = reset()
 
     private fun reset() {
         onGoing = false

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/area/mining/CommissionsAPI.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/area/mining/CommissionsAPI.kt
@@ -96,10 +96,7 @@ object CommissionsAPI {
         this.commissions = emptyList()
     }
 
-    @Subscription
-    fun onDisconnect(event: ServerDisconnectEvent) = reset()
-
-    @Subscription
-    fun onProfileChange(event: ProfileChangeEvent) = reset()
+    @Subscription(ProfileChangeEvent::class, ServerDisconnectEvent::class)
+    fun onProfileChange() = reset()
 }
 

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/area/mining/PowderAPI.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/area/mining/PowderAPI.kt
@@ -45,11 +45,8 @@ object PowderAPI {
         }
     }
 
-    @Subscription
-    fun onDisconnect(event: ServerDisconnectEvent) = reset()
-
-    @Subscription
-    fun onProfileChange(event: ProfileChangeEvent) = reset()
+    @Subscription(ProfileChangeEvent::class, ServerDisconnectEvent::class)
+    fun onProfileChange() = reset()
 
     private fun reset() {
         this.mithril = 0

--- a/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Subscription.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skyblockapi/api/events/base/Subscription.kt
@@ -6,6 +6,11 @@ import kotlin.reflect.KClass
 @Target(AnnotationTarget.FUNCTION)
 annotation class Subscription(
     /**
+     * The event that will be received, only is required if there are no parameters.
+     */
+    vararg val event: KClass<out SkyBlockEvent> = [],
+
+    /**
      * The priority of when the event will be called, lower priority will be called first, see the companion object.
      */
     val priority: Int = 0,
@@ -14,11 +19,6 @@ annotation class Subscription(
      * If the event is cancelled & receiveCancelled is true, then the method will still invoke.
      */
     val receiveCancelled: Boolean = false,
-
-    /**
-     * The event that will be received, only is required if there are no parameters.
-     */
-    vararg val event: KClass<out SkyBlockEvent> = [],
 ) {
 
     companion object {


### PR DESCRIPTION
makes it cleaner when a subscription annotation only has event parameters. also changed some functions to use this