### PR TITLE
fix: some formatted numbers not parsing correctly

### DIFF
--- a/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/utils/extentions/StringExtensions.kt
+++ b/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/utils/extentions/StringExtensions.kt
@@ -41,19 +41,12 @@ fun String?.toFloatValue(): Float = runCatching {
     this?.replace(",", "")?.toFloat() ?: 0f
 }.getOrDefault(0f)
 
-fun String?.parseFormattedLong(default: Long = 0L): Long = runCatching {
-    val commaless = this?.lowercase()?.replace(",", "")
-    val multiplier = formattedMultiplier.entries.firstOrNull { commaless?.endsWith(it.key) == true }?.value
-    return@runCatching if (multiplier != null) {
-        commaless?.dropLast(1)?.toLong()?.times(multiplier) ?: 0
-    } else {
-        commaless?.toLong() ?: 0
-    }
-}.getOrDefault(default)
+fun String?.parseFormattedLong(default: Long = 0L): Long = parseFormattedDouble(default.toDouble()).toLong()
 
 fun String?.parseFormattedInt(default: Int = 0): Int = parseFormattedLong(default.toLong()).toInt()
 
-fun String?.parseFormattedDouble(): Double = runCatching {
+@JvmOverloads
+fun String?.parseFormattedDouble(default: Double = 0.0): Double = runCatching {
     val commaless = this?.lowercase()?.replace(",", "")
     val multiplier = formattedMultiplier.entries.firstOrNull { commaless?.endsWith(it.key) == true }?.value
     return@runCatching if (multiplier != null) {
@@ -61,7 +54,7 @@ fun String?.parseFormattedDouble(): Double = runCatching {
     } else {
         commaless?.toDouble() ?: 0.0
     }
-}.getOrDefault(0.0)
+}.getOrDefault(default)
 
 fun String?.parseFormattedFloat(): Float = parseFormattedDouble().toFloat()
 

--- a/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/utils/text/Text.kt
+++ b/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/utils/text/Text.kt
@@ -229,6 +229,12 @@ object TextStyle {
         set(value) {
             this.style { withStrikethrough(value) }
         }
+
+    var MutableComponent.obfuscated: Boolean
+        get() = this.style.isObfuscated
+        set(value) {
+            this.style { withObfuscated(value) }
+        }
 }
 
 object TextBuilder {


### PR DESCRIPTION
This pr fixes numbers like `123.4k` failing to parse.

The expected value is `123400`
While the actual value was `0` due to it failing to parse because of the `.` in the literal.