### PR TITLE
fix: new mineshaft variants

### DIFF
--- a/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/api/area/mining/mineshaft/MineshaftAPI.kt
+++ b/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/api/area/mining/mineshaft/MineshaftAPI.kt
@@ -32,9 +32,13 @@ object MineshaftAPI {
         "corpse",
         "^\\s*(?<corpse>\\w+): (?<state>.+)$",
     )
+
+    // RUBY_1
+    // RUBY_2
+    // RUBY_C
     private val mineshaftTypeRegex = scoreboardGroup.create(
         "type",
-        "^\\d+/\\d+/\\d+ \\S+ (?<type>\\w{4})(?<number>\\d)$",
+        "^\\d+/\\d+/\\d+ \\S+ (?<type>\\w{4})_(?<variant>\\w)$",
     )
     private val mineshaftFoundRegex = chatGroup.create(
         "found",
@@ -44,8 +48,11 @@ object MineshaftAPI {
     var mineshaftType: MineshaftType? = null
         private set
 
-    var isCrystal: Boolean = false
+    var mineshaftVariant: MineshaftVariant? = null
         private set
+
+    val isCrystal: Boolean
+        get() = mineshaftVariant == MineshaftVariant.CRYSTAL
 
     var scrap: Int = 0
         private set
@@ -85,10 +92,10 @@ object MineshaftAPI {
     @Subscription
     @OnlyIn(SkyBlockIsland.MINESHAFT)
     fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
-        mineshaftTypeRegex.anyFound(event.added, "type", "number") { (type, number) ->
+        mineshaftTypeRegex.anyFound(event.added, "type", "variant") { (type, variant) ->
             this.mineshaftType = MineshaftType.fromId(type)
-            this.isCrystal = number == "2"
-            MineshaftEnteredEvent(mineshaftType, isCrystal).post()
+            this.mineshaftVariant = MineshaftVariant.fromId(variant)
+            MineshaftEnteredEvent(mineshaftType, mineshaftVariant).post()
         }
     }
 
@@ -104,7 +111,7 @@ object MineshaftAPI {
         scrap = 0
         corpses = listOf()
         mineshaftType = null
-        isCrystal = false
+        mineshaftVariant = null
     }
 
     @Subscription

--- a/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/api/area/mining/mineshaft/MineshaftType.kt
+++ b/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/api/area/mining/mineshaft/MineshaftType.kt
@@ -28,3 +28,13 @@ enum class MineshaftType(val id: String) {
         fun fromId(id: String): MineshaftType? = entries.find { it.id.equals(id, true) }
     }
 }
+
+enum class MineshaftVariant(val id: String) {
+    ONE("1"),
+    TWO("2"),
+    CRYSTAL("C");
+
+    companion object {
+        fun fromId(id: String): MineshaftVariant = entries.find { it.id.equals(id, true) } ?: ONE
+    }
+}

--- a/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/api/events/location/mineshaft/MineshaftEnteredEvent.kt
+++ b/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/api/events/location/mineshaft/MineshaftEnteredEvent.kt
@@ -1,6 +1,9 @@
 package tech.thatgravyboat.skyblockapi.api.events.location.mineshaft
 
 import tech.thatgravyboat.skyblockapi.api.area.mining.mineshaft.MineshaftType
+import tech.thatgravyboat.skyblockapi.api.area.mining.mineshaft.MineshaftVariant
 import tech.thatgravyboat.skyblockapi.api.events.base.SkyBlockEvent
 
-data class MineshaftEnteredEvent(val type: MineshaftType?, val isCrystal: Boolean) : SkyBlockEvent()
+data class MineshaftEnteredEvent(val type: MineshaftType?, val variant: MineshaftVariant?) : SkyBlockEvent() {
+    val isCrystal: Boolean = variant == MineshaftVariant.CRYSTAL
+}


### PR DESCRIPTION
they added a second variant for all gemstones except opal & jasper

i think this shouldnt be a breaking change, the only spot where MineshaftEnteredEvent is used doesnt use the values from the event