### PR TITLE
fix: visual stack item count breaking

### DIFF
--- a/src/prc/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
+++ b/src/prc/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
@@ -31,7 +31,7 @@ public abstract class GuiGraphicsVisualItemMixin {
         method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
         at = @At("HEAD")
     )
-    private void renderVisualItem(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
+    private void skyblockapi$renderVisualItem(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
         var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getVisualItem();
         if (visualItem == null) {
             return;
@@ -43,7 +43,7 @@ public abstract class GuiGraphicsVisualItemMixin {
     private final ThreadLocal<ItemStack> skyblockapi$currentItem = new ThreadLocal<>();
 
     @Inject(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V", at = @At("HEAD"))
-    private void renderVisualItemDecoration(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
+    private void skyblockapi$renderVisualItemDecoration(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
         var item = itemStack.get();
         skyblockapi$currentItem.set(item);
         var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(item).skyblockapi$getVisualItem();
@@ -55,9 +55,31 @@ public abstract class GuiGraphicsVisualItemMixin {
 
     @Inject(
         method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
+        at = @At("RETURN")
+    )
+    private void skyblockapi$renderBackgroundItem(CallbackInfo ci) {
+        skyblockapi$currentItem.remove();
+    }
+
+    @Inject(method = "renderItemCount", at = @At("HEAD"))
+    private void skyblockapi$renderItemCount(
+        CallbackInfo ci,
+        @Local(argsOnly = true) LocalRef<String> count,
+        @Local(argsOnly = true) LocalRef<ItemStack> itemStack
+    ) {
+        var slotText = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getSlotText();
+        if (slotText != null) count.set(slotText);
+        else {
+            var item = skyblockapi$currentItem.get();
+            if (item != null) itemStack.set(item);
+        }
+    }
+
+    @Inject(
+        method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
         at = @At("HEAD")
     )
-    public void renderBackgroundItem(
+    private void skyblockapi$renderBackgroundItem(
         CallbackInfo ci,
         @Local(argsOnly = true) ItemStack itemStack,
         @Local(argsOnly = true, ordinal = 0) int x,
@@ -72,28 +94,6 @@ public abstract class GuiGraphicsVisualItemMixin {
             this.pose.popMatrix();
 
             this.nextStratum();
-        }
-    }
-
-    @Inject(
-        method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
-        at = @At("RETURN")
-    )
-    public void renderBackgroundItem(CallbackInfo ci) {
-        skyblockapi$currentItem.remove();
-    }
-
-    @Inject(method = "renderItemCount", at = @At("HEAD"))
-    public void renderItemCount(
-        CallbackInfo ci,
-        @Local(argsOnly = true) LocalRef<String> count,
-        @Local(argsOnly = true) LocalRef<ItemStack> itemStack
-    ) {
-        var slotText = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getSlotText();
-        if (slotText != null) count.set(slotText);
-        else {
-            var item = skyblockapi$currentItem.get();
-            if (item != null) itemStack.set(item);
         }
     }
 

--- a/src/prc/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
+++ b/src/prc/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
@@ -1,7 +1,10 @@
 package tech.thatgravyboat.skyblockapi.mixins;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import org.joml.Matrix3x2fStack;
@@ -42,22 +45,12 @@ public abstract class GuiGraphicsVisualItemMixin {
     @Unique
     private final ThreadLocal<ItemStack> skyblockapi$currentItem = new ThreadLocal<>();
 
-    @Inject(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V", at = @At("HEAD"))
-    private void skyblockapi$renderVisualItemDecoration(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
-        var item = itemStack.get();
-        skyblockapi$currentItem.set(item);
-        var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(item).skyblockapi$getVisualItem();
-        if (visualItem == null) {
-            return;
-        }
-        itemStack.set(visualItem);
-    }
-
-    @Inject(
-        method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
-        at = @At("RETURN")
-    )
-    private void skyblockapi$renderBackgroundItem(CallbackInfo ci) {
+    @WrapMethod(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;II)V")
+    private void skyblockapi$renderItemDecorations(Font font, ItemStack itemStack, int i, int j, Operation<Void> original) {
+        skyblockapi$currentItem.set(itemStack);
+        var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack).skyblockapi$getVisualItem();
+        var item = visualItem != null ? visualItem : itemStack;
+        original.call(font, item, i, j);
         skyblockapi$currentItem.remove();
     }
 

--- a/src/prc/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
+++ b/src/prc/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
@@ -8,6 +8,7 @@ import org.joml.Matrix3x2fStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -26,13 +27,26 @@ public abstract class GuiGraphicsVisualItemMixin {
     @Shadow
     public abstract void nextStratum();
 
-    @Inject(method =
-        {
-            "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
-            "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V"
-        }, at = @At("HEAD"))
-    public void renderVisualItem(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
+    @Inject(
+        method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
+        at = @At("HEAD")
+    )
+    private void renderVisualItem(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
         var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getVisualItem();
+        if (visualItem == null) {
+            return;
+        }
+        itemStack.set(visualItem);
+    }
+
+    @Unique
+    private final ThreadLocal<ItemStack> skyblockapi$currentItem = new ThreadLocal<>();
+
+    @Inject(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V", at = @At("HEAD"))
+    private void renderVisualItemDecoration(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
+        var item = itemStack.get();
+        skyblockapi$currentItem.set(item);
+        var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(item).skyblockapi$getVisualItem();
         if (visualItem == null) {
             return;
         }
@@ -61,17 +75,26 @@ public abstract class GuiGraphicsVisualItemMixin {
         }
     }
 
+    @Inject(
+        method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
+        at = @At("RETURN")
+    )
+    public void renderBackgroundItem(CallbackInfo ci) {
+        skyblockapi$currentItem.remove();
+    }
+
     @Inject(method = "renderItemCount", at = @At("HEAD"))
     public void renderItemCount(
         CallbackInfo ci,
         @Local(argsOnly = true) LocalRef<String> count,
-        @Local(argsOnly = true) ItemStack itemStack
+        @Local(argsOnly = true) LocalRef<ItemStack> itemStack
     ) {
-        var slotText = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack).skyblockapi$getSlotText();
-        if (slotText == null) {
-            return;
+        var slotText = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getSlotText();
+        if (slotText != null) count.set(slotText);
+        else {
+            var item = skyblockapi$currentItem.get();
+            if (item != null) itemStack.set(item);
         }
-        count.set(slotText);
     }
 
 }

--- a/src/prc/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
+++ b/src/prc/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
@@ -20,6 +20,9 @@ import tech.thatgravyboat.skyblockapi.api.item.VisualItemAccessor;
 @Mixin(GuiGraphics.class)
 public abstract class GuiGraphicsVisualItemMixin {
 
+    @Unique
+    private final ThreadLocal<ItemStack> skyblockapi$originalItem = new ThreadLocal<>();
+
     @Shadow
     public abstract void renderItem(ItemStack itemStack, int i, int j);
 
@@ -42,16 +45,13 @@ public abstract class GuiGraphicsVisualItemMixin {
         itemStack.set(visualItem);
     }
 
-    @Unique
-    private final ThreadLocal<ItemStack> skyblockapi$currentItem = new ThreadLocal<>();
-
     @WrapMethod(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;II)V")
     private void skyblockapi$renderItemDecorations(Font font, ItemStack itemStack, int i, int j, Operation<Void> original) {
-        skyblockapi$currentItem.set(itemStack);
+        skyblockapi$originalItem.set(itemStack);
         var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack).skyblockapi$getVisualItem();
         var item = visualItem != null ? visualItem : itemStack;
         original.call(font, item, i, j);
-        skyblockapi$currentItem.remove();
+        skyblockapi$originalItem.remove();
     }
 
     @Inject(method = "renderItemCount", at = @At("HEAD"))
@@ -63,7 +63,7 @@ public abstract class GuiGraphicsVisualItemMixin {
         var slotText = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getSlotText();
         if (slotText != null) count.set(slotText);
         else {
-            var item = skyblockapi$currentItem.get();
+            var item = skyblockapi$originalItem.get();
             if (item != null) itemStack.set(item);
         }
     }

--- a/src/versions/1.21.5/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
+++ b/src/versions/1.21.5/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
@@ -1,8 +1,11 @@
 package tech.thatgravyboat.skyblockapi.mixins;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
@@ -36,22 +39,12 @@ public abstract class GuiGraphicsVisualItemMixin {
     @Unique
     private final ThreadLocal<ItemStack> skyblockapi$currentItem = new ThreadLocal<>();
 
-    @Inject(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V", at = @At("HEAD"))
-    private void skyblockapi$renderVisualItemDecoration(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
-        var item = itemStack.get();
-        skyblockapi$currentItem.set(item);
-        var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(item).skyblockapi$getVisualItem();
-        if (visualItem == null) {
-            return;
-        }
-        itemStack.set(visualItem);
-    }
-
-    @Inject(
-        method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
-        at = @At("RETURN")
-    )
-    private void skyblockapi$renderBackgroundItem(CallbackInfo ci) {
+    @WrapMethod(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;II)V")
+    private void skyblockapi$renderItemDecorations(Font font, ItemStack itemStack, int i, int j, Operation<Void> original) {
+        skyblockapi$currentItem.set(itemStack);
+        var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack).skyblockapi$getVisualItem();
+        var item = visualItem != null ? visualItem : itemStack;
+        original.call(font, item, i, j);
         skyblockapi$currentItem.remove();
     }
 

--- a/src/versions/1.21.5/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
+++ b/src/versions/1.21.5/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
@@ -20,6 +20,9 @@ import tech.thatgravyboat.skyblockapi.api.item.VisualItemAccessor;
 @Mixin(GuiGraphics.class)
 public abstract class GuiGraphicsVisualItemMixin {
 
+    @Unique
+    private final ThreadLocal<ItemStack> skyblockapi$originalItem = new ThreadLocal<>();
+
     @Shadow
     @Final
     private PoseStack pose;
@@ -36,16 +39,13 @@ public abstract class GuiGraphicsVisualItemMixin {
         itemStack.set(visualItem);
     }
 
-    @Unique
-    private final ThreadLocal<ItemStack> skyblockapi$currentItem = new ThreadLocal<>();
-
     @WrapMethod(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;II)V")
     private void skyblockapi$renderItemDecorations(Font font, ItemStack itemStack, int i, int j, Operation<Void> original) {
-        skyblockapi$currentItem.set(itemStack);
+        skyblockapi$originalItem.set(itemStack);
         var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack).skyblockapi$getVisualItem();
         var item = visualItem != null ? visualItem : itemStack;
         original.call(font, item, i, j);
-        skyblockapi$currentItem.remove();
+        skyblockapi$originalItem.remove();
     }
 
     @Inject(method = "renderItemCount", at = @At("HEAD"))
@@ -57,7 +57,7 @@ public abstract class GuiGraphicsVisualItemMixin {
         var slotText = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getSlotText();
         if (slotText != null) count.set(slotText);
         else {
-            var item = skyblockapi$currentItem.get();
+            var item = skyblockapi$originalItem.get();
             if (item != null) itemStack.set(item);
         }
     }

--- a/src/versions/1.21.5/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
+++ b/src/versions/1.21.5/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
@@ -25,7 +25,7 @@ public abstract class GuiGraphicsVisualItemMixin {
     public abstract void renderItem(ItemStack itemStack, int i, int j);
 
     @Inject(method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;IIII)V", at = @At("HEAD"))
-    public void renderVisualItem(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
+    private void skyblockapi$renderVisualItem(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
         var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getVisualItem();
         if (visualItem == null) {
             return;
@@ -37,7 +37,7 @@ public abstract class GuiGraphicsVisualItemMixin {
     private final ThreadLocal<ItemStack> skyblockapi$currentItem = new ThreadLocal<>();
 
     @Inject(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V", at = @At("HEAD"))
-    private void renderVisualItemDecoration(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
+    private void skyblockapi$renderVisualItemDecoration(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
         var item = itemStack.get();
         skyblockapi$currentItem.set(item);
         var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(item).skyblockapi$getVisualItem();
@@ -48,10 +48,32 @@ public abstract class GuiGraphicsVisualItemMixin {
     }
 
     @Inject(
+        method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
+        at = @At("RETURN")
+    )
+    private void skyblockapi$renderBackgroundItem(CallbackInfo ci) {
+        skyblockapi$currentItem.remove();
+    }
+
+    @Inject(method = "renderItemCount", at = @At("HEAD"))
+    private void skyblockapi$renderItemCount(
+        CallbackInfo ci,
+        @Local(argsOnly = true) LocalRef<String> count,
+        @Local(argsOnly = true) LocalRef<ItemStack> itemStack
+    ) {
+        var slotText = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getSlotText();
+        if (slotText != null) count.set(slotText);
+        else {
+            var item = skyblockapi$currentItem.get();
+            if (item != null) itemStack.set(item);
+        }
+    }
+
+    @Inject(
         method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;IIII)V",
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;getItemModelResolver()Lnet/minecraft/client/renderer/item/ItemModelResolver;")
     )
-    public void renderBackgroundItem(
+    private void skyblockapi$renderBackgroundItem(
         CallbackInfo ci,
         @Local(argsOnly = true) ItemStack itemStack,
         @Local(argsOnly = true, ordinal = 0) int x,
@@ -67,18 +89,5 @@ public abstract class GuiGraphicsVisualItemMixin {
         }
     }
 
-    @Inject(method = "renderItemCount", at = @At("HEAD"))
-    public void renderItemCount(
-        CallbackInfo ci,
-        @Local(argsOnly = true) LocalRef<String> count,
-        @Local(argsOnly = true) LocalRef<ItemStack> itemStack
-    ) {
-        var slotText = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getSlotText();
-        if (slotText != null) count.set(slotText);
-        else {
-            var item = skyblockapi$currentItem.get();
-            if (item != null) itemStack.set(item);
-        }
-    }
 
 }

--- a/src/versions/1.21.5/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
+++ b/src/versions/1.21.5/main/java/tech/thatgravyboat/skyblockapi/mixins/GuiGraphicsVisualItemMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -23,13 +24,23 @@ public abstract class GuiGraphicsVisualItemMixin {
     @Shadow
     public abstract void renderItem(ItemStack itemStack, int i, int j);
 
-    @Inject(method =
-        {
-            "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;IIII)V",
-            "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V"
-        }, at = @At("HEAD"))
+    @Inject(method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;IIII)V", at = @At("HEAD"))
     public void renderVisualItem(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
         var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getVisualItem();
+        if (visualItem == null) {
+            return;
+        }
+        itemStack.set(visualItem);
+    }
+
+    @Unique
+    private final ThreadLocal<ItemStack> skyblockapi$currentItem = new ThreadLocal<>();
+
+    @Inject(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V", at = @At("HEAD"))
+    private void renderVisualItemDecoration(CallbackInfo ci, @Local(argsOnly = true) LocalRef<ItemStack> itemStack) {
+        var item = itemStack.get();
+        skyblockapi$currentItem.set(item);
+        var visualItem = VisualItemAccessor.Companion.getVisualItemAccessor(item).skyblockapi$getVisualItem();
         if (visualItem == null) {
             return;
         }
@@ -60,13 +71,14 @@ public abstract class GuiGraphicsVisualItemMixin {
     public void renderItemCount(
         CallbackInfo ci,
         @Local(argsOnly = true) LocalRef<String> count,
-        @Local(argsOnly = true) ItemStack itemStack
+        @Local(argsOnly = true) LocalRef<ItemStack> itemStack
     ) {
-        var slotText = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack).skyblockapi$getSlotText();
-        if (slotText == null) {
-            return;
+        var slotText = VisualItemAccessor.Companion.getVisualItemAccessor(itemStack.get()).skyblockapi$getSlotText();
+        if (slotText != null) count.set(slotText);
+        else {
+            var item = skyblockapi$currentItem.get();
+            if (item != null) itemStack.set(item);
         }
-        count.set(slotText);
     }
 
 }


### PR DESCRIPTION
basically makes it so that if the visual item doesnt have a custom slot text, it uses the original item's stack size