### PR TITLE
Fix: Fusion GUI detection for new shards

### DIFF
--- a/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/hunting/AttributeAPI.kt
+++ b/src/common/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/hunting/AttributeAPI.kt
@@ -182,7 +182,9 @@ object AttributeAPI {
             }
         }
 
-        val shard = event.item.getRawLore().dropWhile { it.matches(fusionItemRegex) }.firstOrNull() ?: return
+        val shard = event.item.getRawLore().dropWhile {
+            it.matches(fusionItemRegex)
+        }.firstOrNull()?.removeSuffix(" NEW SHARD") ?: return
         val id = SkyBlockId.fromName(shard) ?: return
 
         when (event.slot.index) {


### PR DESCRIPTION
Fixes the output shard name being read wrong from the fusion GUI if it is determined to be a "new shard" by Hypixel (none syphoned / in hunting box / whatever the exact criteria is).