### PR TITLE
fix: SlayerAPI memory leak

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/area/slayer/SlayerAPI.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/area/slayer/SlayerAPI.kt
@@ -5,10 +5,8 @@ import net.minecraft.world.entity.Entity
 import tech.thatgravyboat.skyblockapi.api.SkyBlockAPI
 import tech.thatgravyboat.skyblockapi.api.events.base.Subscription
 import tech.thatgravyboat.skyblockapi.api.events.chat.ChatReceivedEvent
-import tech.thatgravyboat.skyblockapi.api.events.entity.ComponentAttachEvent
-import tech.thatgravyboat.skyblockapi.api.events.entity.NameChangedEvent
-import tech.thatgravyboat.skyblockapi.api.events.entity.SlayerInfoLineAttachEvent
-import tech.thatgravyboat.skyblockapi.api.events.entity.SlayerInfoLineChangeEvent
+import tech.thatgravyboat.skyblockapi.api.events.entity.*
+import tech.thatgravyboat.skyblockapi.api.events.hypixel.ServerChangeEvent
 import tech.thatgravyboat.skyblockapi.api.events.info.ScoreboardUpdateEvent
 import tech.thatgravyboat.skyblockapi.api.events.misc.RegisterCommandsEvent
 import tech.thatgravyboat.skyblockapi.utils.extentions.parseFormattedInt
@@ -154,6 +152,16 @@ object SlayerAPI {
                 )
             }
         }
+    }
+
+    @Subscription
+    fun onEntityRemoved(event: EntityRemovedEvent) {
+        slayerBosses.remove(event.entity)
+    }
+
+    @Subscription
+    fun onWorldChange(event: ServerChangeEvent) {
+        slayerBosses.clear()
     }
 }
 

--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/area/slayer/SlayerInfo.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/area/slayer/SlayerInfo.kt
@@ -4,21 +4,18 @@ import net.minecraft.world.entity.Entity
 import tech.thatgravyboat.skyblockapi.helpers.McPlayer
 import tech.thatgravyboat.skyblockapi.helpers.getStrippedAttachedLines
 import tech.thatgravyboat.skyblockapi.utils.DiscoverableValue
-import java.lang.ref.WeakReference
 
-data class SlayerInfo(val entity: WeakReference<Entity>) {
-    constructor(entity: Entity) : this(WeakReference(entity))
-
+data class SlayerInfo(val entity: Entity) {
     private fun discoverTypeIfNeeded(): SlayerMob? {
         return SLAYER_MOBS.find { mob ->
             val inGameNames = mob.inGameNames
-            entity.get()?.getStrippedAttachedLines()?.any { line -> inGameNames.any { line.contains(it) } } ?: false
+            entity.getStrippedAttachedLines().any { line -> inGameNames.any { line.contains(it) } }
         }
     }
 
     private fun discoverOwner(): String? {
-        return entity.get()?.getStrippedAttachedLines()
-            ?.find { it.startsWith("spawned by: ", ignoreCase = true) }
+        return entity.getStrippedAttachedLines()
+            .find { it.startsWith("spawned by: ", ignoreCase = true) }
             ?.substringAfterLast(":")?.trim()
     }
 

--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/area/slayer/SlayerInfo.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/area/slayer/SlayerInfo.kt
@@ -4,18 +4,21 @@ import net.minecraft.world.entity.Entity
 import tech.thatgravyboat.skyblockapi.helpers.McPlayer
 import tech.thatgravyboat.skyblockapi.helpers.getStrippedAttachedLines
 import tech.thatgravyboat.skyblockapi.utils.DiscoverableValue
+import java.lang.ref.WeakReference
 
-data class SlayerInfo(val entity: Entity) {
+data class SlayerInfo(val entity: WeakReference<Entity>) {
+    constructor(entity: Entity) : this(WeakReference(entity))
+
     private fun discoverTypeIfNeeded(): SlayerMob? {
         return SLAYER_MOBS.find { mob ->
             val inGameNames = mob.inGameNames
-            entity.getStrippedAttachedLines().any { line -> inGameNames.any { line.contains(it) } }
+            entity.get()?.getStrippedAttachedLines()?.any { line -> inGameNames.any { line.contains(it) } } ?: false
         }
     }
 
     private fun discoverOwner(): String? {
-        return entity.getStrippedAttachedLines()
-            .find { it.startsWith("spawned by: ", ignoreCase = true) }
+        return entity.get()?.getStrippedAttachedLines()
+            ?.find { it.startsWith("spawned by: ", ignoreCase = true) }
             ?.substringAfterLast(":")?.trim()
     }
 


### PR DESCRIPTION
Removes keys in the `slayerBosses` map on Entity removal, as the values strongly reference their own keys.