### PR TITLE
fix(MayorData): MayorPerk equality check

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/data/MayorData.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/data/MayorData.kt
@@ -62,9 +62,18 @@ data class MayorPerk internal constructor(
     var description: String = "Not available",
 ) {
     internal var overrideState: TriState = DEFAULT
+
     var active: Boolean = false
         get() = overrideState.toBoolean(field)
         internal set
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is MayorPerk) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
 }
 
 


### PR DESCRIPTION
Fixes `MayorPerk`s that should be equal not being treated as such because of the mutable `description` field.

This fixes SkyOcean's "Minister in Calendar" feature duplicating perks, and possibly other things.