### PR TITLE
docs(InstantExtensions): fix deprecation replacements

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/utils/time/InstantExtensions.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/utils/time/InstantExtensions.kt
@@ -7,21 +7,21 @@ import kotlin.time.Duration
 import kotlin.time.Instant
 import kotlin.time.toJavaInstant
 
-@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extensions.currentInstant"))
+@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extentions.currentInstant"))
 fun currentInstant(): Instant = Clock.System.now()
 
-@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extensions.fromNow"))
+@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extentions.fromNow"))
 fun Duration.fromNow(): Instant = currentInstant() + this
 
-@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extensions.ago"))
+@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extentions.ago"))
 fun Duration.ago(): Instant = currentInstant() - this
 
-@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extensions.since"))
+@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extentions.since"))
 fun Instant.since(): Duration = currentInstant() - this
 
-@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extensions.until"))
+@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extentions.until"))
 fun Instant.until(): Duration = this - currentInstant()
 
-@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extensions.format"))
+@RemoveNextVersion(ReplaceWith("tech.thatgravyboat.skyblockapi.utils.extentions.format"))
 fun DateTimeFormatter.format(instant: Instant): String = this.format(instant.toJavaInstant())
 *///? }


### PR DESCRIPTION
The package name is unfortunately misspelled, and changing it would break ABI compatibility. Someone helpfully spelled it correctly here, which led to invalid references.