### PR TITLE
fix: vanilla registries being created every ops usage

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/utils/json/Json.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/utils/json/Json.kt
@@ -18,8 +18,13 @@ import kotlin.reflect.typeOf
 object Json {
 
     val gson: Gson = GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create()
+
+    private val vanillaRegistry by lazy {
+        VanillaRegistries.createLookup()
+    }
+
     internal val ops: DynamicOps<JsonElement> get() {
-        val registry = McClient.connection?.registryAccess() ?: VanillaRegistries.createLookup()
+        val registry = McClient.connection?.registryAccess() ?: vanillaRegistry
         return RegistryOps.create(JsonOps.INSTANCE, LenientHolderLookupAdapter(registry))
     }
 


### PR DESCRIPTION
cache the vanilla registries, no need to create them every time a json file is loaded