### PR TITLE
feat(EnchantmentIdResolver): make id assignment work everywhere in bz and hex

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/remote/api/resolvers/EnchantmentIdResolver.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/remote/api/resolvers/EnchantmentIdResolver.kt
@@ -3,11 +3,13 @@ package tech.thatgravyboat.skyblockapi.api.remote.api.resolvers
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import net.minecraft.world.inventory.AbstractContainerMenu
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 import tech.thatgravyboat.repolib.api.RepoAPI
 import tech.thatgravyboat.skyblockapi.api.remote.api.SkyBlockId
 import tech.thatgravyboat.skyblockapi.impl.debug.ItemDebugCategory
 import tech.thatgravyboat.skyblockapi.impl.debug.addDebugString
 import tech.thatgravyboat.skyblockapi.utils.extentions.cleanName
+import tech.thatgravyboat.skyblockapi.utils.extentions.parseRomanNumeral
 import tech.thatgravyboat.skyblockapi.utils.extentions.toIntValue
 import tech.thatgravyboat.skyblockapi.utils.text.TextProperties.stripped
 
@@ -19,28 +21,33 @@ private val nameToIdLookup = RepoAPI.enchantments().enchantments().map { (id, en
     enchantments.name to id
 }.toMap()
 
+private fun resolveEnchantedBookId(name: String, level: Int?): SkyBlockId? {
+    if (level != null) {
+        val id = nameToIdLookup[name] ?: return null
+        //this.addDebugString{ "Name to id: $name -> $id" } // idk how to add this back and have it under the resolver that called the function :(
+        return SkyBlockId.enchantment(id, level).asDerived()
+    }
+    return idLookup[name]?.asDerived()
+}
+
 @IdResolvers
 internal data object EnchantmentTableAndHexEnchantmentIdResolver : InventoryIdResolver {
+    private val titleRegex = "(?:The Hex ➜ )?Enchant Item(?: ➜ (.*))?".toRegex()
     override fun <T : AbstractContainerMenu> ItemStack.isApplicable(
         menu: AbstractContainerScreen<T>,
         resolverKind: IdResolverKind,
     ): Boolean {
-        val stripped = menu.title.stripped
-        val isHex = stripped == "The Hex ➜ Enchant Item"
-        val isTable = stripped == "Enchant Item"
-
-        addDebugString { "Is Hex: $isHex; Is Table: $isTable" }
-        return isHex || isTable
+        if (item != Items.ENCHANTED_BOOK) return false
+        return (titleRegex.matches(menu.title.stripped))
     }
 
-    override fun <T : AbstractContainerMenu> ItemStack.resolveId(
-        menu: AbstractContainerScreen<T>,
-        resolverKind: IdResolverKind,
-    ): SkyBlockId? {
-        val name = this.cleanName
-        val lookup = idLookup[name]
-        this.addDebugString { "Name to id: $name -> $lookup" }
-        return lookup?.asDerived()
+    override fun <T : AbstractContainerMenu> ItemStack.resolveId(menu: AbstractContainerScreen<T>, resolverKind: IdResolverKind): SkyBlockId? {
+        val title = menu.title.stripped
+        val isInBuyPage = !titleRegex.find(title)?.groupValues[1].isNullOrEmpty()
+        val name = if (isInBuyPage) cleanName.substringBeforeLast(" ") else cleanName
+        val level = if (isInBuyPage) cleanName.substringAfterLast(" ").parseRomanNumeral() else null
+        addDebugString { "BooksWithLevels: $isInBuyPage" }
+        return resolveEnchantedBookId(name, level)
     }
 
     override val priority: Int = 10
@@ -48,20 +55,34 @@ internal data object EnchantmentTableAndHexEnchantmentIdResolver : InventoryIdRe
 
 @IdResolvers
 internal data object BazaarEnchantmentIdResolver : InventoryIdResolver {
+    private val titleRegex = ("(?:\\(\\d+/\\d+\\) )?(Normal |Ultimate )?Enchantments(?: ➜ .*)?").toRegex()
     override fun <T : AbstractContainerMenu> ItemStack.isApplicable(
         menu: AbstractContainerScreen<T>,
         resolverKind: IdResolverKind,
     ): Boolean {
         val title = menu.title.stripped
         if (!title.contains("➜")) return false
-        return title.substringAfter(")").substringBefore("➜").trim() == "Enchantments"
+        if (item != Items.ENCHANTED_BOOK) return false
+
+        val name = cleanName.substringBeforeLast(" ").trim()
+        val isInBuyPage = title.substringBeforeLast("➜").trim() == name
+
+        return (titleRegex.matches(title) || isInBuyPage)
     }
 
     override fun <T : AbstractContainerMenu> ItemStack.resolveId(
         menu: AbstractContainerScreen<T>,
         resolverKind: IdResolverKind,
     ): SkyBlockId? {
-        return idLookup[this.cleanName.substringBeforeLast(" ").trim()]?.asDerived()
+        val title = menu.title.stripped
+        val name = cleanName.substringBeforeLast(" ").trim()
+        val isInBuyPage = title.substringBeforeLast("➜").trim() == name
+        val isInNormalOrUltimatePage = !titleRegex.find(title)?.groupValues[1].isNullOrEmpty()
+        addDebugString { "Is In Buy Page: $isInBuyPage; Is In Normal/Ultimate Page: $isInNormalOrUltimatePage" }
+
+        val level = if (isInBuyPage || isInNormalOrUltimatePage) cleanName.substringAfterLast(" ").trim().parseRomanNumeral() else null
+
+        return resolveEnchantedBookId(name, level)
     }
 
     override val priority: Int = 10
@@ -72,6 +93,7 @@ internal data object EnchantmentGuideIdResolver : InventoryIdResolver, ItemDebug
     private val titleRegex = ".* Enchantments Guide".toRegex()
 
     override fun <T : AbstractContainerMenu> ItemStack.isApplicable(menu: AbstractContainerScreen<T>, resolverKind: IdResolverKind): Boolean {
+        if (item != Items.ENCHANTED_BOOK) return false
         val matchesTitle = titleRegex.matches(menu.title.stripped)
         this.addDebugString {
             "Title Match: $matchesTitle"
@@ -81,11 +103,8 @@ internal data object EnchantmentGuideIdResolver : InventoryIdResolver, ItemDebug
 
     override fun <T : AbstractContainerMenu> ItemStack.resolveId(menu: AbstractContainerScreen<T>, resolverKind: IdResolverKind): SkyBlockId? {
         val name = this.cleanName.substringBeforeLast(" ").trim()
-        val lookup = nameToIdLookup[name]
-        this.addDebugString { "Name to id: $name -> $lookup" }
-        val id = lookup ?: return null
         val level = this.cleanName.substringAfterLast(" ").trim().toIntValue()
-        return SkyBlockId.enchantment(id, level).asDerived()
+        return resolveEnchantedBookId(name, level)
     }
 
     override val priority: Int = 10

--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/remote/api/resolvers/EnchantmentIdResolver.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/remote/api/resolvers/EnchantmentIdResolver.kt
@@ -21,10 +21,11 @@ private val nameToIdLookup = RepoAPI.enchantments().enchantments().map { (id, en
     enchantments.name to id
 }.toMap()
 
-private fun resolveEnchantedBookId(name: String, level: Int?): SkyBlockId? {
+context(_: ItemDebugCategory)
+private fun ItemStack.resolveEnchantedBookId(name: String, level: Int?): SkyBlockId? {
     if (level != null) {
         val id = nameToIdLookup[name] ?: return null
-        //this.addDebugString{ "Name to id: $name -> $id" } // idk how to add this back and have it under the resolver that called the function :(
+        this.addDebugString { "Name to id: $name -> $id" }
         return SkyBlockId.enchantment(id, level).asDerived()
     }
     return idLookup[name]?.asDerived()
@@ -46,7 +47,7 @@ internal data object EnchantmentTableAndHexEnchantmentIdResolver : InventoryIdRe
         val isInBuyPage = !titleRegex.find(title)?.groupValues[1].isNullOrEmpty()
         val name = if (isInBuyPage) cleanName.substringBeforeLast(" ") else cleanName
         val level = if (isInBuyPage) cleanName.substringAfterLast(" ").parseRomanNumeral() else null
-        addDebugString { "BooksWithLevels: $isInBuyPage" }
+        addDebugString { "is In Buy Page: $isInBuyPage" }
         return resolveEnchantedBookId(name, level)
     }
 


### PR DESCRIPTION
this method of detecting feels really overcomplicated tho, surely I'm just dumb and there is a smarter and more performant way that is not checking if the title matches 18 quintillion times.

also idk if I should keep the enchantment_book check because I can see the admins replacing every single item with paper that has a different item model when they release the official resourcepack.