### PR TITLE
fix(MaxwellPower): buttery power

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/maxwell/MaxwellPower.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/maxwell/MaxwellPower.kt
@@ -59,5 +59,5 @@ object MaxwellPowers {
     val BUBBA = register("BUBBA_BLISTER", "Bubba")
     val SANGUISUGE = register("DISPLACED_LEECH", "Sanguisuge")
     val FROZEN = register("GLACITE_SHARD", "Frozen")
-
+    val BUTTERY = register("SUNFLOWER_BUTTER", "Buttery")
 }


### PR DESCRIPTION
adds support for the buttery power (tested on csb)

maxwellApi probably needs some sort of migration to start using accessory power instead of magical power internally btw