### PR TITLE
feat: Moonglade Marsh & Critter Safari display names

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/location/SkyBlockIsland.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/location/SkyBlockIsland.kt
@@ -19,9 +19,9 @@ enum class SkyBlockIsland(val id: String, displayName: String? = null) {
     GARDEN("garden"),
     BACKWATER_BAYOU("fishing_1"),
     LOTUS_ATOLL("lotus_atoll"),
-    GALATEA("foraging_2"),
+    GALATEA("foraging_2", "Moonglade Marsh"),
     TORRHUS_CANYON("foraging_3"),
-    SAFARI("safari"),
+    SAFARI("safari", "Critter Safari"),
 
     THE_RIFT("rift"),
     DARK_AUCTION("dark_auction"),


### PR DESCRIPTION
I considered adding a new `MOONGLADE_MARSH` entry and `@RemoveNextVersion GALATEA` but I don't think you can override equality in enums so it would need a bunch of hacky checks, so I'm just leaving it for now.