### PR TITLE
fix(LoreDataTypes): rarity line detection false positives

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/datatype/defaults/LoreDataTypes.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/datatype/defaults/LoreDataTypes.kt
@@ -89,6 +89,7 @@ object LoreDataTypes {
         val lines = rawLore?.asReversedIterator() ?: return null
         for (line in lines) {
             val rarityLine = (if (isUpgraded) line.drop(2).dropLast(2).trim() else line.trim()).removePrefix("SHINY ")
+            if (rarityLine.any(Char::isLowerCase)) continue
             val rarity = SkyBlockRarity.entries.firstOrNull { rarity -> rarityLine.startsWith(rarity.displayName.uppercase()) }
             if (rarity != null) {
                 return rarityLine to rarity


### PR DESCRIPTION
Attempts to fix things like Rabbit Godmother Shard being broken in Iconographic etc. because they happen to mention a rarity mid-lore-line. Basically, this enforces that the whole line must consist of uppercase letters only. Not tested, but should be fine, since e.g. recombobulated items (which would be like `a DIVINE a`) already get the `.drop(2).dropLast(2)` treatment.