### PR TITLE
fix: attributeAPI & maxwellAPI inventory title detection

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/hunting/AttributeAPI.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/hunting/AttributeAPI.kt
@@ -49,11 +49,11 @@ object AttributeAPI {
     private val inventoryGroup = RegexGroup.INVENTORY.group("attribute")
 
     private val attributeMenuGroup = inventoryGroup.group("attribute_menu")
-    private val attributeMenuRegex = attributeMenuGroup.create("title", "^Attribute Menu$")
+    val attributeMenuRegex = attributeMenuGroup.create("title", "^(?:\\((?<currentPage>\\d+)/\\d+\\) )?Attribute Menu$")
     private val syphonMoreRegex = attributeMenuGroup.create("more", "^Syphon (\\d+) more to level up!")
 
     private val huntingBoxGroup = inventoryGroup.group("hunting_box")
-    private val huntingBoxMenuRegex = huntingBoxGroup.create("title", "^Hunting Box$")
+    val huntingBoxMenuRegex = huntingBoxGroup.create("title", "^(?:\\((?<currentPage>\\d+)/\\d+\\) )?Hunting Box$")
     private val ownedRegex = huntingBoxGroup.create("owned", "^Owned: (?<amount>[\\d,.]+) Shards?$")
     private val attributeMaxedRegex = huntingBoxGroup.create("maxed", "^Attribute Maxed!$")
     private val levelRegex = huntingBoxGroup.create("level", "[IXV0-9]+")
@@ -125,7 +125,7 @@ object AttributeAPI {
     @OnlyOnSkyBlock
     fun huntingBox(event: InventoryChangeEvent) {
         if (!event.title.matches(huntingBoxMenuRegex)) return
-        if (event.isOnSides) return
+        if (!event.isInMainPart) return
 
         val id = event.item[DataTypes.SKYBLOCK_ID] ?: return
         val data = SkyBlockAttributesRepo.get(id.cleanId) ?: return

--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/maxwell/MaxwellAPI.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/maxwell/MaxwellAPI.kt
@@ -13,7 +13,6 @@ import tech.thatgravyboat.skyblockapi.api.events.chat.ChatReceivedEvent
 import tech.thatgravyboat.skyblockapi.api.events.misc.RegisterCommandsEvent
 import tech.thatgravyboat.skyblockapi.api.events.screen.ContainerInitializedEvent
 import tech.thatgravyboat.skyblockapi.api.events.screen.InventoryChangeEvent
-import tech.thatgravyboat.skyblockapi.api.profile.items.loadout.LoadoutAPI
 import tech.thatgravyboat.skyblockapi.api.profile.items.loadout.LoadoutAPI.loadoutDebug
 import tech.thatgravyboat.skyblockapi.api.profile.items.loadout.LoadoutChangeEvent
 import tech.thatgravyboat.skyblockapi.api.profile.items.loadout.value
@@ -77,7 +76,7 @@ object MaxwellAPI {
     private val thaumaturgyGuiGroup = inventoryGroup.group("thaumaturgy")
     private val thaumaturgyTitleRegex = thaumaturgyGuiGroup.create(
         "title",
-        "^Accessory Bag Thaumaturgy$",
+        "^(?:\\((?<currentPage>\\d+)/\\d+\\) )?Accessory Bag Thaumatur?g?y?$",
     )
     private val selectedPowerRegex = thaumaturgyGuiGroup.create(
         "selected",

--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/maxwell/MaxwellAPI.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/maxwell/MaxwellAPI.kt
@@ -76,7 +76,7 @@ object MaxwellAPI {
     private val thaumaturgyGuiGroup = inventoryGroup.group("thaumaturgy")
     private val thaumaturgyTitleRegex = thaumaturgyGuiGroup.create(
         "title",
-        "^(?:\\((?<currentPage>\\d+)/\\d+\\) )?Accessory Bag Thaumatur?g?y?$",
+        "^(?:\\((?<currentPage>\\d+)/\\d+\\) )?Accessory Bag Thaumaturgy$",
     )
     private val selectedPowerRegex = thaumaturgyGuiGroup.create(
         "selected",

--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/remote/api/resolvers/AttributeMenuResolver.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/remote/api/resolvers/AttributeMenuResolver.kt
@@ -3,7 +3,7 @@ package tech.thatgravyboat.skyblockapi.api.remote.api.resolvers
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import net.minecraft.world.inventory.AbstractContainerMenu
 import net.minecraft.world.item.ItemStack
-import net.minecraft.world.item.Items
+import tech.thatgravyboat.skyblockapi.api.profile.hunting.AttributeAPI
 import tech.thatgravyboat.skyblockapi.api.remote.api.SimpleItemAPI
 import tech.thatgravyboat.skyblockapi.api.remote.api.SkyBlockId
 import tech.thatgravyboat.skyblockapi.impl.ColoredItems
@@ -18,7 +18,7 @@ data object AttributeMenuResolver : InventoryIdResolver {
         menu: AbstractContainerScreen<T>,
         resolverKind: IdResolverKind,
     ): Boolean {
-        return menu.title.stripped == "Attribute Menu"
+        return AttributeAPI.attributeMenuRegex.matches(menu.title.stripped)
     }
 
     override fun <T : AbstractContainerMenu> ItemStack.resolveId(

--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/remote/api/resolvers/HuntingBoxResolver.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/remote/api/resolvers/HuntingBoxResolver.kt
@@ -3,6 +3,7 @@ package tech.thatgravyboat.skyblockapi.api.remote.api.resolvers
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import net.minecraft.world.inventory.AbstractContainerMenu
 import net.minecraft.world.item.ItemStack
+import tech.thatgravyboat.skyblockapi.api.profile.hunting.AttributeAPI
 import tech.thatgravyboat.skyblockapi.api.remote.api.SimpleItemAPI
 import tech.thatgravyboat.skyblockapi.api.remote.api.SkyBlockId
 import tech.thatgravyboat.skyblockapi.utils.extentions.cleanName
@@ -15,7 +16,7 @@ data object HuntingBoxResolver : InventoryIdResolver {
         menu: AbstractContainerScreen<T>,
         resolverKind: IdResolverKind,
     ): Boolean {
-        return menu.title.stripped == "Hunting Box"
+        return AttributeAPI.huntingBoxMenuRegex.matches(menu.title.stripped)
     }
 
     override fun <T : AbstractContainerMenu> ItemStack.resolveId(


### PR DESCRIPTION
new hb title
<img width="230" height="59" alt="image" src="https://github.com/user-attachments/assets/84fe705b-e085-46cc-a8da-c27dbac47280" />

new am title
<img width="280" height="59" alt="image" src="https://github.com/user-attachments/assets/172b26a0-ed0a-453a-947b-638c10ccf557" />

new maxwell title  ~~(yes, it gets cut off if you have more than one page... )~~ I'm blind...
<img width="407" height="73" alt="image" src="https://github.com/user-attachments/assets/1f4cdaad-dc87-4160-9a66-1a76494487cd" />

these title changes actually happened a few weeks ago and some stuff did get fixed, but I think these two slipped through the cracks

oh yeah and the resolvers for attributeAPI needed updating too