### PR TITLE
fix: add support for singular "Token" in SkillTreeAPI tokensRegex

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/skilltree/SkillTreeAPI.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/skilltree/SkillTreeAPI.kt
@@ -26,7 +26,7 @@ abstract class SkillTreeAPI<Data : SkillTreeData<Perk>, Perk : SkillTreePerk, Se
     protected open val levelRegex = inventoryGroup.create("level", "Level (?<level>\\d+)(?:/\\d+)?")
     protected open val disabledRegex = inventoryGroup.create("disabled", "DISABLED|Click to select!")
     protected open val mainItemRegex = inventoryGroup.create("mainitem", "Heart of the $identifier")
-    protected open val tokensRegex = inventoryGroup.create("tokens", "Tokens of the $identifier: (?<tokens>\\d+)")
+    protected open val tokensRegex = inventoryGroup.create("tokens", "Tokens? of the $identifier: (?<tokens>\\d+)")
     protected open val tierRegex = inventoryGroup.create("tier", "Tier (?<tier>\\d+)")
     protected open val tierUnlockedRegex = inventoryGroup.create("tier.unlocked", "UNLOCKED")
 


### PR DESCRIPTION
In the heart of the mountain tooltip it says Token of the Mountain: X (singular) meanwhile heart of the forest uses Tokens of the Forest: X

So just changed the regex to `Tokens?` so it matches both and detects both correctly