### PR TITLE
fix: add support for roman numerals so that the skills api shows skill lvl correctly

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/skillxp/SkillExpAPI.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skyblockapi/api/profile/skillxp/SkillExpAPI.kt
@@ -24,7 +24,7 @@ object SkillExpAPI {
     val skills: Map<HypixelSkillAPI.Skill, Float> get() = SkillExpStorage.data?.exp ?: emptyMap()
 
     private val group = RegexGroup.INVENTORY.group("skillexp")
-    private val itemNameRegex = group.create("itemName", "(?<name>.*) (?<level>\\d+)")
+    private val itemNameRegex = group.create("itemName", "(?<name>.*) (?<level>\\d+|[IVXLCDMivxlcdm]+)")
     private val itemLoreXpRegex = group.create("itemLoreExp", "^\\s+(?<current>[\\d,.]+)(?:/(?<needed>[\\d,.]+[kmbKMB]?))?")
 
     @Subscription
@@ -36,7 +36,8 @@ object SkillExpAPI {
 
         itemNameRegex.match(event.item.cleanName, "name", "level") { (name, level) ->
             val skill = HypixelSkillAPI.Skill.getByName(name) ?: return@match
-            val level = level.toIntValue()
+            val level = level.parseRomanOrArabic()
+            if (level <= 0) return@match
 
             itemLoreXpRegex.anyMatch(event.item.getRawLore(), "current") { (current) ->
                 val xp = if (skill.data.maxLevel == level) {


### PR DESCRIPTION
If the skill level in the skill menu is displayed in Roman numerals (like `Mining XXXIX` or `Farming LV`), the lookup fails because the regex was only looking for regular numbers. Because of this, opening the menu didn't parse those skills and caused skill levels and XP to be recorded incorrectly. I have updated the regex to accept both numbers and Roman numerals and used `parseRomanOrArabic()` so the skill level and experience are parsed properly in both cases.